### PR TITLE
Make transactions audit-only: remove balance updates from TransactionService

### DIFF
--- a/java/src/main/java/io/github/HenriqueMichelini/craftalism/api/service/TransactionService.java
+++ b/java/src/main/java/io/github/HenriqueMichelini/craftalism/api/service/TransactionService.java
@@ -17,16 +17,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class TransactionService {
 
     private final TransactionRepository repository;
-    private final BalanceService balanceService;
     private final TransactionMapper mapper;
 
     public TransactionService(
         TransactionRepository repository,
-        BalanceService balanceService,
         TransactionMapper mapper
     ) {
         this.repository = repository;
-        this.balanceService = balanceService;
         this.mapper = mapper;
     }
 
@@ -36,12 +33,6 @@ public class TransactionService {
     ) {
         long amount = dto.amount();
         if (amount <= 0) throw new InvalidAmountException();
-
-        balanceService.transfer(
-            dto.fromPlayerUuid(),
-            dto.toPlayerUuid(),
-            amount
-        );
 
         Transaction tx = new Transaction(
             dto.fromPlayerUuid(),

--- a/java/src/test/java/io/github/HenriqueMichelini/craftalism/api/service/TransactionServiceTest.java
+++ b/java/src/test/java/io/github/HenriqueMichelini/craftalism/api/service/TransactionServiceTest.java
@@ -27,16 +27,13 @@ class TransactionServiceTest {
     private TransactionRepository repository;
 
     @Mock
-    private BalanceService balanceService;
-
-    @Mock
     private TransactionMapper mapper;
 
     @InjectMocks
     private TransactionService service;
 
     @Test
-    void processTransaction_success_callsTransferAndSavesAndReturnsMappedDto() {
+    void processTransaction_success_savesAndReturnsMappedDto() {
         UUID from = UUID.randomUUID();
         UUID to = UUID.randomUUID();
         long amount = 123L;
@@ -52,8 +49,6 @@ class TransactionServiceTest {
         TransactionResponseDTO result = service.processTransaction(req);
 
         assertSame(responseDto, result);
-
-        verify(balanceService).transfer(from, to, amount);
 
         ArgumentCaptor<Transaction> captor = ArgumentCaptor.forClass(
             Transaction.class
@@ -78,7 +73,6 @@ class TransactionServiceTest {
             service.processTransaction(req)
         );
 
-        verifyNoInteractions(balanceService);
         verifyNoInteractions(repository);
         verifyNoInteractions(mapper);
     }
@@ -95,7 +89,7 @@ class TransactionServiceTest {
 
         assertSame(txs, result);
         verify(repository).findAll();
-        verifyNoInteractions(balanceService, mapper);
+        verifyNoInteractions(mapper);
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- Ensure transactions serve only as an audit/log and do not modify balances so balance mutations are managed exclusively by the `BalanceService` and `/api/balances` endpoints. 
- Prevent duplicated transfer side effects and enforce single source of truth for balance changes.

### Description
- Removed the `BalanceService` dependency from `TransactionService` and stopped calling `balanceService.transfer(...)` from `processTransaction(...)` so no balances are modified during transaction creation. 
- Kept validation and transactional integrity by retaining the `@Transactional` annotation and the `InvalidAmountException` check (`amount <= 0`).
- `processTransaction(...)` now only constructs and persists a `Transaction` entity and returns the mapped `TransactionResponseDTO`.
- Updated `TransactionServiceTest` to remove transfer-related expectations and to assert that valid transactions are persisted and invalid amounts throw without persisting.

### Testing
- Ran the targeted unit test command `./gradlew test --tests io.github.HenriqueMichelini.craftalism.api.service.TransactionServiceTest`, which failed in this environment with a JVM/Gradle runtime mismatch error: `Unsupported class file major version 69`, so tests could not be executed here.
- Updated unit tests (`TransactionServiceTest`) to reflect the new audit-only behavior (no balance transfers); these test changes are part of the patch but could not be run due to the environment JVM mismatch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c32af7d5448323920840c30c3562b5)