### PR TITLE
Fix transaction route compatibility and deterministic transaction errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The API is a stateless OAuth2 resource server. JWTs are validated against the is
 
 | Scope | Permitted methods |
 |---|---|
-| `SCOPE_api:read` | `GET /api/**` |
+| *(no scope required)* | `GET /api/**` (public read policy for current MVP) |
 | `SCOPE_api:write` | `POST`, `PUT`, `PATCH`, `DELETE` on `/api/**` |
 
 Public paths (no token required): `GET /actuator/health`, `/swagger-ui/**`, `/v3/api-docs/**`.
@@ -158,18 +158,18 @@ Base path: `/api`. Full interactive documentation is available at `http://localh
 
 | Method | Path | Scope | Description |
 |---|---|---|---|
-| `GET` | `/players` | `api:read` | List all players. |
-| `GET` | `/players/{uuid}` | `api:read` | Get player by UUID. |
-| `GET` | `/players/name/{name}` | `api:read` | Get player by display name. |
+| `GET` | `/players` | public | List all players. |
+| `GET` | `/players/{uuid}` | public | Get player by UUID. |
+| `GET` | `/players/name/{name}` | public | Get player by display name. |
 | `POST` | `/players` | `api:write` | Register a new player. |
 
 ### Balances
 
 | Method | Path | Scope | Description |
 |---|---|---|---|
-| `GET` | `/balances` | `api:read` | List all balances. |
-| `GET` | `/balances/{uuid}` | `api:read` | Get a player's balance. |
-| `GET` | `/balances/top` | `api:read` | Top balances. `?limit=` clamped to 1–20, default 10. |
+| `GET` | `/balances` | public | List all balances. |
+| `GET` | `/balances/{uuid}` | public | Get a player's balance. |
+| `GET` | `/balances/top` | public | Top balances. `?limit=` clamped to 1–20, default 10. |
 | `POST` | `/balances` | `api:write` | Create a balance record for a player. |
 | `PUT` | `/balances/{uuid}/set` | `api:write` | Overwrite a player's balance. |
 | `POST` | `/balances/{uuid}/deposit` | `api:write` | Add funds to a player's balance. |
@@ -179,10 +179,10 @@ Base path: `/api`. Full interactive documentation is available at `http://localh
 
 | Method | Path | Scope | Description |
 |---|---|---|---|
-| `GET` | `/transactions` | `api:read` | List all transactions. |
-| `GET` | `/transactions/id/{id}` | `api:read` | Get transaction by ID. |
-| `GET` | `/transactions/from/{uuid}` | `api:read` | List outgoing transactions for a player. |
-| `GET` | `/transactions/to/{uuid}` | `api:read` | List incoming transactions for a player. |
+| `GET` | `/transactions` | public | List all transactions. |
+| `GET` | `/transactions/{id}` | public | Get transaction by ID. Legacy alias `/transactions/id/{id}` is also accepted. |
+| `GET` | `/transactions/from/{uuid}` | public | List outgoing transactions for a player. |
+| `GET` | `/transactions/to/{uuid}` | public | List incoming transactions for a player. |
 | `POST` | `/transactions` | `api:write` | Store a transaction record. Does not update balances. |
 
 ---

--- a/java/src/main/java/io/github/HenriqueMichelini/craftalism/api/controller/TransactionController.java
+++ b/java/src/main/java/io/github/HenriqueMichelini/craftalism/api/controller/TransactionController.java
@@ -89,7 +89,7 @@ public class TransactionController {
             ),
         }
     )
-    @GetMapping("/id/{id}")
+    @GetMapping({ "/{id}", "/id/{id}" })
     public ResponseEntity<TransactionResponseDTO> getTransactionById(
         @Parameter(
             description = "Transaction identifier",
@@ -197,7 +197,7 @@ public class TransactionController {
             ),
             @ApiResponse(
                 responseCode = "404",
-                description = "Sender or receiver balance not found"
+                description = "Sender or receiver player not found"
             ),
             @ApiResponse(
                 responseCode = "422",
@@ -218,7 +218,7 @@ public class TransactionController {
         TransactionResponseDTO created = service.processTransaction(dto);
 
         URI location = ServletUriComponentsBuilder.fromCurrentRequest()
-            .path("/id/{id}")
+            .path("/{id}")
             .buildAndExpand(created.id())
             .toUri();
 

--- a/java/src/main/java/io/github/HenriqueMichelini/craftalism/api/service/TransactionService.java
+++ b/java/src/main/java/io/github/HenriqueMichelini/craftalism/api/service/TransactionService.java
@@ -3,9 +3,11 @@ package io.github.HenriqueMichelini.craftalism.api.service;
 import io.github.HenriqueMichelini.craftalism.api.dto.TransactionRequestDTO;
 import io.github.HenriqueMichelini.craftalism.api.dto.TransactionResponseDTO;
 import io.github.HenriqueMichelini.craftalism.api.exceptions.InvalidAmountException;
+import io.github.HenriqueMichelini.craftalism.api.exceptions.PlayerNotFoundException;
 import io.github.HenriqueMichelini.craftalism.api.exceptions.TransactionNotFoundException;
 import io.github.HenriqueMichelini.craftalism.api.mapper.TransactionMapper;
 import io.github.HenriqueMichelini.craftalism.api.model.Transaction;
+import io.github.HenriqueMichelini.craftalism.api.repository.PlayerRepository;
 import io.github.HenriqueMichelini.craftalism.api.repository.TransactionRepository;
 import java.util.List;
 import java.util.UUID;
@@ -17,13 +19,16 @@ import org.springframework.transaction.annotation.Transactional;
 public class TransactionService {
 
     private final TransactionRepository repository;
+    private final PlayerRepository playerRepository;
     private final TransactionMapper mapper;
 
     public TransactionService(
         TransactionRepository repository,
+        PlayerRepository playerRepository,
         TransactionMapper mapper
     ) {
         this.repository = repository;
+        this.playerRepository = playerRepository;
         this.mapper = mapper;
     }
 
@@ -33,6 +38,12 @@ public class TransactionService {
     ) {
         long amount = dto.amount();
         if (amount <= 0) throw new InvalidAmountException();
+        if (!playerRepository.existsById(dto.fromPlayerUuid())) {
+            throw new PlayerNotFoundException(dto.fromPlayerUuid());
+        }
+        if (!playerRepository.existsById(dto.toPlayerUuid())) {
+            throw new PlayerNotFoundException(dto.toPlayerUuid());
+        }
 
         Transaction tx = new Transaction(
             dto.fromPlayerUuid(),

--- a/java/src/test/java/io/github/HenriqueMichelini/craftalism/api/controller/TransactionControllerTest.java
+++ b/java/src/test/java/io/github/HenriqueMichelini/craftalism/api/controller/TransactionControllerTest.java
@@ -146,7 +146,7 @@ public class TransactionControllerTest {
 
             // create an actual UriComponents to return from buildAndExpand(...)
             UriComponents uriComponents = UriComponentsBuilder.fromUriString(
-                "http://localhost/api/transactions/id/555"
+                "http://localhost/api/transactions/555"
             ).build();
 
             // static method returns the mock builder
@@ -155,7 +155,7 @@ public class TransactionControllerTest {
                 .thenReturn(builder);
 
             // stub fluent methods
-            when(builder.path("/id/{id}")).thenReturn(builder);
+            when(builder.path("/{id}")).thenReturn(builder);
             when(builder.buildAndExpand(555L)).thenReturn(uriComponents);
 
             ResponseEntity<TransactionResponseDTO> resp =
@@ -167,7 +167,7 @@ public class TransactionControllerTest {
             URI location = resp.getHeaders().getLocation();
             assertNotNull(location);
             assertEquals(
-                "http://localhost/api/transactions/id/555",
+                "http://localhost/api/transactions/555",
                 location.toString()
             );
 

--- a/java/src/test/java/io/github/HenriqueMichelini/craftalism/api/service/TransactionServiceTest.java
+++ b/java/src/test/java/io/github/HenriqueMichelini/craftalism/api/service/TransactionServiceTest.java
@@ -6,9 +6,11 @@ import static org.mockito.Mockito.*;
 import io.github.HenriqueMichelini.craftalism.api.dto.TransactionRequestDTO;
 import io.github.HenriqueMichelini.craftalism.api.dto.TransactionResponseDTO;
 import io.github.HenriqueMichelini.craftalism.api.exceptions.InvalidAmountException;
+import io.github.HenriqueMichelini.craftalism.api.exceptions.PlayerNotFoundException;
 import io.github.HenriqueMichelini.craftalism.api.exceptions.TransactionNotFoundException;
 import io.github.HenriqueMichelini.craftalism.api.mapper.TransactionMapper;
 import io.github.HenriqueMichelini.craftalism.api.model.Transaction;
+import io.github.HenriqueMichelini.craftalism.api.repository.PlayerRepository;
 import io.github.HenriqueMichelini.craftalism.api.repository.TransactionRepository;
 import java.util.List;
 import java.util.Optional;
@@ -27,6 +29,9 @@ class TransactionServiceTest {
     private TransactionRepository repository;
 
     @Mock
+    private PlayerRepository playerRepository;
+
+    @Mock
     private TransactionMapper mapper;
 
     @InjectMocks
@@ -43,6 +48,8 @@ class TransactionServiceTest {
         Transaction savedTx = mock(Transaction.class);
         TransactionResponseDTO responseDto = mock(TransactionResponseDTO.class);
 
+        when(playerRepository.existsById(from)).thenReturn(true);
+        when(playerRepository.existsById(to)).thenReturn(true);
         when(repository.save(any(Transaction.class))).thenReturn(savedTx);
         when(mapper.toDto(savedTx)).thenReturn(responseDto);
 
@@ -65,6 +72,43 @@ class TransactionServiceTest {
     }
 
     @Test
+    void processTransaction_missingSender_throwsPlayerNotFoundException() {
+        UUID from = UUID.randomUUID();
+        UUID to = UUID.randomUUID();
+        TransactionRequestDTO req = new TransactionRequestDTO(from, to, 123L);
+
+        when(playerRepository.existsById(from)).thenReturn(false);
+
+        assertThrows(PlayerNotFoundException.class, () ->
+            service.processTransaction(req)
+        );
+
+        verify(playerRepository).existsById(from);
+        verify(playerRepository, never()).existsById(to);
+        verifyNoInteractions(repository);
+        verifyNoInteractions(mapper);
+    }
+
+    @Test
+    void processTransaction_missingReceiver_throwsPlayerNotFoundException() {
+        UUID from = UUID.randomUUID();
+        UUID to = UUID.randomUUID();
+        TransactionRequestDTO req = new TransactionRequestDTO(from, to, 123L);
+
+        when(playerRepository.existsById(from)).thenReturn(true);
+        when(playerRepository.existsById(to)).thenReturn(false);
+
+        assertThrows(PlayerNotFoundException.class, () ->
+            service.processTransaction(req)
+        );
+
+        verify(playerRepository).existsById(from);
+        verify(playerRepository).existsById(to);
+        verifyNoInteractions(repository);
+        verifyNoInteractions(mapper);
+    }
+
+    @Test
     void processTransaction_amountZeroOrNegative_throwsAndDoesNotCallDependencies() {
         TransactionRequestDTO req = mock(TransactionRequestDTO.class);
         when(req.amount()).thenReturn(0L); // test zero; negative case is equivalent
@@ -73,6 +117,7 @@ class TransactionServiceTest {
             service.processTransaction(req)
         );
 
+        verifyNoInteractions(playerRepository);
         verifyNoInteractions(repository);
         verifyNoInteractions(mapper);
     }


### PR DESCRIPTION
### Motivation
- Canonical transaction detail route differed from common client expectations (`/transactions/{id}` vs `/transactions/id/{id}`), causing API contract drift.  
- `POST /api/transactions` persisted transactions without validating sender/receiver existence, making error semantics non-deterministic.  
- README documented a scope-protected `GET` policy while the code intentionally permits public `GET /api/**`, so docs and code were out of sync.

### Description
- Added a canonical mapping `GET /api/transactions/{id}` while keeping the legacy alias `/api/transactions/id/{id}` to preserve compatibility, and updated the controller to expose both (`TransactionController`).
- Changed `POST /api/transactions` `Location` header generation to use the canonical `/{id}` path (`TransactionController`).
- Hardened `TransactionService.processTransaction` to check sender and receiver existence via `PlayerRepository.existsById(...)` and throw `PlayerNotFoundException` before persisting, making 404 semantics deterministic (`TransactionService`).
- Updated unit tests to cover the canonical URI generation and the new missing-player validation behavior (`TransactionControllerTest`, `TransactionServiceTest`).
- Updated `README.md` to reflect the repository's current public-read policy for `GET /api/**` and to document the canonical transaction detail path with a legacy alias note.

### Testing
- Updated unit tests under `java/src/test/...` to match the new controller behavior and validation and they were committed to the branch.  
- Attempted to run the full test suite with `cd java && ./gradlew test`, but the build failed in this environment with `Unsupported class file major version 69` (tooling/JVM/Gradle compatibility issue), so automated tests could not be executed here.  
- Verified compilation-level edits and ran lightweight repository inspections to ensure the new imports/constructors and controller signatures are consistent with the rest of the codebase.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d040f1a6308323b3e1c19cca46a288)