### PR TITLE
Add resilient transfer-incident recording, CI quality gate, docs and tests

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -10,7 +10,32 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
+  quality-gate:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ./java
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: gradle
+
+      - name: Verify Gradle wrapper
+        uses: gradle/actions/wrapper-validation@v4
+
+      - name: Run quality checks
+        run: ./gradlew --no-daemon clean check
+
   build-and-push:
+    needs: quality-gate
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -1,0 +1,33 @@
+name: Quality Gates
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  backend-quality:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ./java
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: Verify Gradle wrapper
+        uses: gradle/actions/wrapper-validation@v4
+
+      - name: Compile and run checks
+        run: ./gradlew --no-daemon clean check

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Craftalism API is the central data service for the economy platform. It expo
 - Player registration and lookup by UUID or display name.
 - Balance lifecycle management: create, deposit, withdraw, set, and rank.
 - Transaction record storage between players.
-- JWT scope-based authorization for all endpoints.
+- JWT scope-based authorization for protected write endpoints.
 - Standardized RFC 9457 `ProblemDetail` error responses.
 - Interactive API documentation via Swagger UI (local profile).
 
@@ -115,6 +115,13 @@ All errors are returned as RFC 9457 `ProblemDetail` with these additional fields
 | `path` | Request path. |
 | `errors` | Field-level validation map (validation errors only). |
 
+### Troubleshooting quick checks
+
+- **Issuer mismatch at startup**  
+  If the API fails fast with an issuer mismatch error, verify `AUTH_ISSUER_URI` is aligned between API, auth server, and deployment environment.
+- **Transfer failures with incident warnings**  
+  Transfer incident recording is diagnostic. If incident persistence fails, the API logs a critical error and preserves the original transfer response semantics.
+
 ---
 
 ## Running Locally
@@ -186,6 +193,14 @@ Base path: `/api`. Full interactive documentation is available at `http://localh
 | `GET` | `/transactions/to/{uuid}` | public | List incoming transactions for a player. |
 | `POST` | `/transactions` | `api:write` | Store a transaction record. Does not update balances. |
 
+### Transfer incidents (diagnostic)
+
+Incident records are persisted by the transfer workflow for failure/conflict diagnostics (for example idempotency conflicts and unexpected transfer failures). Records can be queried through:
+
+| Method | Path | Scope | Description |
+|---|---|---|---|
+| `GET` | `/transfer-incidents` | public | List recorded transfer incidents with incident type, reason, metadata, and idempotency correlation context. |
+
 ---
 
 ## Testing
@@ -229,7 +244,7 @@ java/
 
 - List endpoints have no pagination or filtering support; all records are returned in a single response.
 - Integration tests do not run against a real PostgreSQL instance.
-- No CI pipeline is configured.
+- Repository workflows currently enforce checks, but branch protection/required status enforcement is configured outside this repository.
 
 ---
 
@@ -237,7 +252,7 @@ java/
 
 - Add pagination and filtering to all list endpoints.
 - Add integration tests against real PostgreSQL with actual security tokens.
-- Add CI pipeline with lint, typecheck, build, and test stages.
+- Add contract-focused smoke tests covering token issuance + protected write + read verification across composed services.
 
 ---
 

--- a/java/src/main/java/io/github/HenriqueMichelini/craftalism/api/service/TransferService.java
+++ b/java/src/main/java/io/github/HenriqueMichelini/craftalism/api/service/TransferService.java
@@ -19,10 +19,12 @@ import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.util.HexFormat;
 import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 public class TransferService {
 
@@ -72,13 +74,14 @@ public class TransferService {
         );
 
         if (!record.getRequestHash().equals(requestHash)) {
-            incidentService.recordIncident(
+            recordIncidentSafely(
                 "IDEMPOTENCY_CONFLICT",
                 from,
                 to,
                 normalizedKey,
                 "Idempotency key was reused with a different transfer payload",
-                "expectedHash=" + record.getRequestHash() + ", actualHash=" + requestHash
+                "expectedHash=" + record.getRequestHash() + ", actualHash=" + requestHash,
+                null
             );
             throw new IdempotencyConflictException(normalizedKey);
         }
@@ -111,13 +114,14 @@ public class TransferService {
             );
             return new BalanceTransferResponseDTO(response, false);
         } catch (RuntimeException ex) {
-            incidentService.recordIncident(
+            recordIncidentSafely(
                 "TRANSFER_CRITICAL_FAILURE",
                 from,
                 to,
                 normalizedKey,
                 ex.getMessage(),
-                "exception=" + ex.getClass().getName()
+                "exception=" + ex.getClass().getName(),
+                ex
             );
             throw ex;
         }
@@ -195,6 +199,44 @@ public class TransferService {
             return idempotencyRepository
                 .findForUpdateByIdempotencyKey(normalizedKey)
                 .orElseThrow(() -> ex);
+        }
+    }
+
+    private void recordIncidentSafely(
+        String type,
+        UUID from,
+        UUID to,
+        String idempotencyKey,
+        String reason,
+        String metadata,
+        Exception originalFailure
+    ) {
+        try {
+            incidentService.recordIncident(
+                type,
+                from,
+                to,
+                idempotencyKey,
+                reason,
+                metadata
+            );
+        } catch (RuntimeException incidentError) {
+            if (originalFailure == null) {
+                log.error(
+                    "Critical: failed to persist transfer incident for type={} idempotencyKey={}",
+                    type,
+                    idempotencyKey,
+                    incidentError
+                );
+            } else {
+                log.error(
+                    "Critical: failed to persist transfer incident while handling transfer failure. type={} idempotencyKey={} originalError={}",
+                    type,
+                    idempotencyKey,
+                    originalFailure.getClass().getName(),
+                    incidentError
+                );
+            }
         }
     }
 }

--- a/java/src/test/java/io/github/HenriqueMichelini/craftalism/api/controller/BalanceTransferIntegrationTest.java
+++ b/java/src/test/java/io/github/HenriqueMichelini/craftalism/api/controller/BalanceTransferIntegrationTest.java
@@ -13,6 +13,7 @@ import io.github.HenriqueMichelini.craftalism.api.repository.BalanceRepository;
 import io.github.HenriqueMichelini.craftalism.api.repository.PlayerRepository;
 import io.github.HenriqueMichelini.craftalism.api.repository.TransactionRepository;
 import io.github.HenriqueMichelini.craftalism.api.repository.TransferIncidentRepository;
+import io.github.HenriqueMichelini.craftalism.api.service.TransferIncidentService;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -46,6 +47,9 @@ class BalanceTransferIntegrationTest {
 
     @MockitoSpyBean
     private TransactionRepository transactionRepositorySpy;
+
+    @MockitoSpyBean
+    private TransferIncidentService incidentServiceSpy;
 
     private UUID senderId;
     private UUID receiverId;
@@ -202,6 +206,32 @@ class BalanceTransferIntegrationTest {
     }
 
     @Test
+    void transfer_idempotencyConflict_stillReturns409_whenIncidentRecordingFails()
+        throws Exception {
+        doThrow(new RuntimeException("incident persistence unavailable"))
+            .when(incidentServiceSpy)
+            .recordIncident(any(), any(), any(), any(), any(), any());
+
+        mockMvc
+            .perform(
+                post("/api/balances/transfer")
+                    .header("Idempotency-Key", "idem-conflict-incident-failure")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(payload(senderId, receiverId, 100))
+            )
+            .andExpect(status().isOk());
+
+        mockMvc
+            .perform(
+                post("/api/balances/transfer")
+                    .header("Idempotency-Key", "idem-conflict-incident-failure")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(payload(senderId, receiverId, 200))
+            )
+            .andExpect(status().isConflict());
+    }
+
+    @Test
     void transfer_rollsBackWhenTransactionPersistenceFails() throws Exception {
         doThrow(new RuntimeException("ledger db failure"))
             .when(transactionRepositorySpy)
@@ -222,6 +252,33 @@ class BalanceTransferIntegrationTest {
         org.junit.jupiter.api.Assertions.assertEquals(100L, receiver.getAmount());
         org.junit.jupiter.api.Assertions.assertEquals(0, transactionRepository.count());
         org.junit.jupiter.api.Assertions.assertEquals(1, incidentRepository.count());
+    }
+
+    @Test
+    void transfer_preservesPrimaryFailure_whenTransactionAndIncidentPersistenceFail()
+        throws Exception {
+        doThrow(new RuntimeException("ledger db failure"))
+            .when(transactionRepositorySpy)
+            .save(any(Transaction.class));
+        doThrow(new RuntimeException("incident persistence unavailable"))
+            .when(incidentServiceSpy)
+            .recordIncident(any(), any(), any(), any(), any(), any());
+
+        mockMvc
+            .perform(
+                post("/api/balances/transfer")
+                    .header("Idempotency-Key", "idem-dual-failure")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(payload(senderId, receiverId, 120))
+            )
+            .andExpect(status().isInternalServerError());
+
+        Balance sender = balanceRepository.findById(senderId).orElseThrow();
+        Balance receiver = balanceRepository.findById(receiverId).orElseThrow();
+        org.junit.jupiter.api.Assertions.assertEquals(1000L, sender.getAmount());
+        org.junit.jupiter.api.Assertions.assertEquals(100L, receiver.getAmount());
+        org.junit.jupiter.api.Assertions.assertEquals(0, transactionRepository.count());
+        org.junit.jupiter.api.Assertions.assertEquals(0, incidentRepository.count());
     }
 
     private String payload(UUID from, UUID to, long amount) {


### PR DESCRIPTION
### Motivation

- Ensure transfer workflow persists diagnostic incident records without masking or altering the original transfer failure semantics. 
- Enforce backend quality checks in CI before image build/push to catch build/test problems early. 
- Improve documentation and visibility around transfer incidents and quick troubleshooting checks.

### Description

- Added `recordIncidentSafely` to `TransferService`, switched incident recording calls to use this safe wrapper, and added `@Slf4j` logging to surface failures when incident persistence itself fails. 
- Propagated original failure context to the safe recorder so transfer failures remain the primary error even when incident recording fails. 
- Extended integration tests in `BalanceTransferIntegrationTest` with a `@MockitoSpyBean` for `TransferIncidentService` and added tests for incident-persistence failure scenarios (`transfer_idempotencyConflict_stillReturns409_whenIncidentRecordingFails` and `transfer_preservesPrimaryFailure_whenTransactionAndIncidentPersistenceFail`). 
- Added a CI quality gate job to `/.github/workflows/build-and-push.yml` and introduced a standalone workflow `/.github/workflows/quality-gates.yml` that runs `./gradlew --no-daemon clean check` in the `./java` directory. 
- Updated `README.md` with troubleshooting quick checks and a public `GET /transfer-incidents` diagnostic endpoint description plus minor wording clarifications.

### Testing

- Ran `./gradlew test` which executed unit and Spring MVC integration tests and completed successfully. 
- New integration tests for incident persistence failure scenarios were executed and passed. 
- Existing transfer rollback and idempotency tests were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3337fa798832380724edb84ec102a)